### PR TITLE
Do not show links to non existant objects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not show links to non-existent objects
+  [raphael-s]
 
 
 1.1.1 (2016-07-06)

--- a/ftw/servicenavigation/form.py
+++ b/ftw/servicenavigation/form.py
@@ -152,8 +152,11 @@ class ServiceLinksRow(object):
 
         # Start hack
         if value and name == 'internal_link':
-            obj = getSite().unrestrictedTraverse(value.lstrip('/'))
-            value = create_relation_for(obj)
+            try:
+                obj = getSite().unrestrictedTraverse(value.lstrip('/'))
+                value = create_relation_for(obj)
+            except KeyError:
+                value = None
         # End hack
 
         return value

--- a/ftw/servicenavigation/tests/test_service_navigation.py
+++ b/ftw/servicenavigation/tests/test_service_navigation.py
@@ -185,3 +185,17 @@ class TestServiceNavigation(FunctionalTestCase):
         browser.fill({'Disable service links': True}).save()
         self.assertIsNone(browser.find('Internal link'))
         self.assertIsNone(browser.find('External link'))
+
+    @browsing
+    def test_link_to_non_existent_object_is_not_displayed(self, browser):
+        self.set_links(self.portal)
+        self.portal.manage_delObjects(self.portal.get('a-folder').id)
+        transaction.commit()
+
+        browser.login().visit(self.portal, view='service_navigation_form')
+        browser.find_form_by_fields('Disable service links').submit()
+
+        self.assertEqual(
+            [item.text for item in browser.css(
+                '#service-navigation ul li a:not(.ModifyServiceNavigation)')],
+            ['External Link'])

--- a/ftw/servicenavigation/viewlet.py
+++ b/ftw/servicenavigation/viewlet.py
@@ -31,10 +31,12 @@ class ServiceNavigation(ViewletBase):
             return []
 
         for link in storage.get('links', []):
-            links.append(
-                dict(label=link['label'],
-                     icon=link['icon'],
-                     url=self.get_link(link)))
+            link_url = self.get_link(link)
+            if link_url:
+                links.append(
+                    dict(label=link['label'],
+                         icon=link['icon'],
+                         url=link_url))
 
         return links
 
@@ -43,8 +45,11 @@ class ServiceNavigation(ViewletBase):
         external_link = link['external_url']
 
         if internal_link:
-            internal_link = api.portal.get().unrestrictedTraverse(
-                internal_link.lstrip('/'))
+            try:
+                internal_link = api.portal.get().unrestrictedTraverse(
+                    internal_link.lstrip('/'))
+            except KeyError:
+                internal_link = None
             if internal_link:
                 internal_link = internal_link.absolute_url()
 


### PR DESCRIPTION
see: https://github.com/4teamwork/bern.web/pull/1165 :
Links in the service navigation are no longer displayed, when the link-destination is a non-existent object. Links can point to non-existent objects if those were deleted after the link got created.
If an object which has been linked in the service-navigation gets deleted, the link to it will not be removed immediately, because the navigation is stored in cache. To renew the cache somebody has to click the save button in the service-navigation list or the server has to be restarted. As long as none of those two steps have been done, the link will still be visible and leading to an error page (object not found)

closes #13 