### PR TITLE
Improvements for Servicenavigation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
+- Validate that there is either an external or an internal link but not both. [elioschmutz]
 - Extend the form to define the _blank attribute for each link. [elioschmutz]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Extend the form to define the _blank attribute for each link. [elioschmutz]
 
 
 1.1.3 (2019-08-15)

--- a/ftw/servicenavigation/form.py
+++ b/ftw/servicenavigation/form.py
@@ -80,6 +80,13 @@ class IServiceNavigationSchemaGrid(model.Schema):
         required=False,
     )
 
+    blank = schema.Bool(
+        title=_(u'label_blank', default=u'Open in new window'),
+        required=False,
+        default=False,
+        missing_value=False,
+    )
+
 
 class IServiceNavigationSchema(model.Schema):
     directives.widget('links', DataGridFieldFactory, allow_reorder=True)

--- a/ftw/servicenavigation/form.py
+++ b/ftw/servicenavigation/form.py
@@ -23,6 +23,8 @@ from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.interface import alsoProvides
 from zope.interface import implements
+from zope.interface import Invalid
+from zope.interface import invariant
 from zope.intid.interfaces import IIntIds
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.vocabulary import SimpleVocabulary
@@ -114,6 +116,13 @@ class IServiceNavigationSchema(model.Schema):
         default=True,
         missing_value=True,
     )
+
+    @invariant
+    def link_validator(data):
+        for link in data.links:
+            if link.get('internal_link', None) and link.get('external_url', None):
+                raise Invalid(_('error_link_validator',
+                                u'Choose between an external or an internal link.'))
 
 
 class ServiceNavigationConfig(object):

--- a/ftw/servicenavigation/locales/de/LC_MESSAGES/ftw.servicenavigation.po
+++ b/ftw/servicenavigation/locales/de/LC_MESSAGES/ftw.servicenavigation.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-19 12:31+0000\n"
+"POT-Creation-Date: 2019-08-19 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Install ftw.servicenavigation"
 msgstr ""
 
-#: ./ftw/servicenavigation/form.py:61
+#: ./ftw/servicenavigation/form.py:63
 msgid "Label"
 msgstr "Label"
 
@@ -27,6 +27,11 @@ msgstr ""
 msgid "Service navigation"
 msgstr "Servicenavigation"
 
+#. Default: "Choose between an external or an internal link."
+#: ./ftw/servicenavigation/form.py:95
+msgid "error_link_validator"
+msgstr "Pro Zeile darf nur ein externer oder ein interner Link angegeben werden. Beides ist nicht erlaubt."
+
 #: ./ftw/servicenavigation/profiles.zcml:13
 msgid "ftw.servicenavigation (default)"
 msgstr ""
@@ -36,27 +41,27 @@ msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
 #. Default: "Open in new window"
-#: ./ftw/servicenavigation/form.py:84
+#: ./ftw/servicenavigation/form.py:86
 msgid "label_blank"
 msgstr "In neuem Fenster öffnen?"
 
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:104
+#: ./ftw/servicenavigation/form.py:112
 msgid "label_disable_service_links"
 msgstr "Service-Links nicht anzeigen"
 
 #. Default: "External URL"
-#: ./ftw/servicenavigation/form.py:72
+#: ./ftw/servicenavigation/form.py:74
 msgid "label_external_url"
 msgstr "Externe URL"
 
 #. Default: "Icon"
-#: ./ftw/servicenavigation/form.py:66
+#: ./ftw/servicenavigation/form.py:68
 msgid "label_icon"
 msgstr "Icon"
 
 #. Default: "Internal link"
-#: ./ftw/servicenavigation/form.py:78
+#: ./ftw/servicenavigation/form.py:80
 msgid "label_internal_link"
 msgstr "Interner Link"
 
@@ -66,12 +71,12 @@ msgid "label_modify_service_navigation"
 msgstr "Service-Navigation bearbeiten"
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:94
+#: ./ftw/servicenavigation/form.py:102
 msgid "label_service_links"
 msgstr "Service-Links"
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:185
+#: ./ftw/servicenavigation/form.py:193
 msgid "label_service_navigation"
 msgstr "Service-Navigation"
 

--- a/ftw/servicenavigation/locales/de/LC_MESSAGES/ftw.servicenavigation.po
+++ b/ftw/servicenavigation/locales/de/LC_MESSAGES/ftw.servicenavigation.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-24 09:25+0000\n"
+"POT-Creation-Date: 2019-08-19 12:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,8 +35,13 @@ msgstr ""
 msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
+#. Default: "Open in new window"
+#: ./ftw/servicenavigation/form.py:84
+msgid "label_blank"
+msgstr "In neuem Fenster öffnen?"
+
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:97
+#: ./ftw/servicenavigation/form.py:104
 msgid "label_disable_service_links"
 msgstr "Service-Links nicht anzeigen"
 
@@ -56,17 +61,17 @@ msgid "label_internal_link"
 msgstr "Interner Link"
 
 #. Default: "Modify service navigation"
-#: ./ftw/servicenavigation/templates/viewlet.pt:22
+#: ./ftw/servicenavigation/templates/viewlet.pt:23
 msgid "label_modify_service_navigation"
 msgstr "Service-Navigation bearbeiten"
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:87
+#: ./ftw/servicenavigation/form.py:94
 msgid "label_service_links"
 msgstr "Service-Links"
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:178
+#: ./ftw/servicenavigation/form.py:185
 msgid "label_service_navigation"
 msgstr "Service-Navigation"
 

--- a/ftw/servicenavigation/locales/en/LC_MESSAGES/ftw.servicenavigation.po
+++ b/ftw/servicenavigation/locales/en/LC_MESSAGES/ftw.servicenavigation.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-24 09:25+0000\n"
+"POT-Creation-Date: 2019-08-19 12:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,8 +38,13 @@ msgstr ""
 msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
+#. Default: "Open in new window"
+#: ./ftw/servicenavigation/form.py:84
+msgid "label_blank"
+msgstr ""
+
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:97
+#: ./ftw/servicenavigation/form.py:104
 msgid "label_disable_service_links"
 msgstr ""
 
@@ -59,17 +64,17 @@ msgid "label_internal_link"
 msgstr ""
 
 #. Default: "Modify service navigation"
-#: ./ftw/servicenavigation/templates/viewlet.pt:22
+#: ./ftw/servicenavigation/templates/viewlet.pt:23
 msgid "label_modify_service_navigation"
 msgstr ""
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:87
+#: ./ftw/servicenavigation/form.py:94
 msgid "label_service_links"
 msgstr ""
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:178
+#: ./ftw/servicenavigation/form.py:185
 msgid "label_service_navigation"
 msgstr ""
 

--- a/ftw/servicenavigation/locales/en/LC_MESSAGES/ftw.servicenavigation.po
+++ b/ftw/servicenavigation/locales/en/LC_MESSAGES/ftw.servicenavigation.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-19 12:31+0000\n"
+"POT-Creation-Date: 2019-08-19 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Install ftw.servicenavigation"
 msgstr ""
 
-#: ./ftw/servicenavigation/form.py:61
+#: ./ftw/servicenavigation/form.py:63
 msgid "Label"
 msgstr ""
 
@@ -30,6 +30,11 @@ msgstr ""
 msgid "Service navigation"
 msgstr "Service navigation screen"
 
+#. Default: "Choose between an external or an internal link."
+#: ./ftw/servicenavigation/form.py:95
+msgid "error_link_validator"
+msgstr ""
+
 #: ./ftw/servicenavigation/profiles.zcml:13
 msgid "ftw.servicenavigation (default)"
 msgstr ""
@@ -39,27 +44,27 @@ msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
 #. Default: "Open in new window"
-#: ./ftw/servicenavigation/form.py:84
+#: ./ftw/servicenavigation/form.py:86
 msgid "label_blank"
 msgstr ""
 
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:104
+#: ./ftw/servicenavigation/form.py:112
 msgid "label_disable_service_links"
 msgstr ""
 
 #. Default: "External URL"
-#: ./ftw/servicenavigation/form.py:72
+#: ./ftw/servicenavigation/form.py:74
 msgid "label_external_url"
 msgstr ""
 
 #. Default: "Icon"
-#: ./ftw/servicenavigation/form.py:66
+#: ./ftw/servicenavigation/form.py:68
 msgid "label_icon"
 msgstr ""
 
 #. Default: "Internal link"
-#: ./ftw/servicenavigation/form.py:78
+#: ./ftw/servicenavigation/form.py:80
 msgid "label_internal_link"
 msgstr ""
 
@@ -69,12 +74,12 @@ msgid "label_modify_service_navigation"
 msgstr ""
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:94
+#: ./ftw/servicenavigation/form.py:102
 msgid "label_service_links"
 msgstr ""
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:185
+#: ./ftw/servicenavigation/form.py:193
 msgid "label_service_navigation"
 msgstr ""
 

--- a/ftw/servicenavigation/locales/fr/LC_MESSAGES/ftw.servicenavigation.po
+++ b/ftw/servicenavigation/locales/fr/LC_MESSAGES/ftw.servicenavigation.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-19 12:31+0000\n"
+"POT-Creation-Date: 2019-08-19 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Install ftw.servicenavigation"
 msgstr ""
 
-#: ./ftw/servicenavigation/form.py:61
+#: ./ftw/servicenavigation/form.py:63
 msgid "Label"
 msgstr "Label"
 
@@ -30,6 +30,11 @@ msgstr ""
 msgid "Service navigation"
 msgstr "Navigation de service"
 
+#. Default: "Choose between an external or an internal link."
+#: ./ftw/servicenavigation/form.py:95
+msgid "error_link_validator"
+msgstr ""
+
 #: ./ftw/servicenavigation/profiles.zcml:13
 msgid "ftw.servicenavigation (default)"
 msgstr ""
@@ -39,27 +44,27 @@ msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
 #. Default: "Open in new window"
-#: ./ftw/servicenavigation/form.py:84
+#: ./ftw/servicenavigation/form.py:86
 msgid "label_blank"
 msgstr ""
 
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:104
+#: ./ftw/servicenavigation/form.py:112
 msgid "label_disable_service_links"
 msgstr "Déactiver les liens de service"
 
 #. Default: "External URL"
-#: ./ftw/servicenavigation/form.py:72
+#: ./ftw/servicenavigation/form.py:74
 msgid "label_external_url"
 msgstr "Addresse externe"
 
 #. Default: "Icon"
-#: ./ftw/servicenavigation/form.py:66
+#: ./ftw/servicenavigation/form.py:68
 msgid "label_icon"
 msgstr "Icône"
 
 #. Default: "Internal link"
-#: ./ftw/servicenavigation/form.py:78
+#: ./ftw/servicenavigation/form.py:80
 msgid "label_internal_link"
 msgstr "Lien interne"
 
@@ -69,12 +74,12 @@ msgid "label_modify_service_navigation"
 msgstr "Modifier la navigation de service"
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:94
+#: ./ftw/servicenavigation/form.py:102
 msgid "label_service_links"
 msgstr "Liens de service"
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:185
+#: ./ftw/servicenavigation/form.py:193
 msgid "label_service_navigation"
 msgstr "Navigation de service"
 

--- a/ftw/servicenavigation/locales/fr/LC_MESSAGES/ftw.servicenavigation.po
+++ b/ftw/servicenavigation/locales/fr/LC_MESSAGES/ftw.servicenavigation.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-24 09:25+0000\n"
+"POT-Creation-Date: 2019-08-19 12:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,8 +38,13 @@ msgstr ""
 msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
+#. Default: "Open in new window"
+#: ./ftw/servicenavigation/form.py:84
+msgid "label_blank"
+msgstr ""
+
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:97
+#: ./ftw/servicenavigation/form.py:104
 msgid "label_disable_service_links"
 msgstr "Déactiver les liens de service"
 
@@ -59,17 +64,17 @@ msgid "label_internal_link"
 msgstr "Lien interne"
 
 #. Default: "Modify service navigation"
-#: ./ftw/servicenavigation/templates/viewlet.pt:22
+#: ./ftw/servicenavigation/templates/viewlet.pt:23
 msgid "label_modify_service_navigation"
 msgstr "Modifier la navigation de service"
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:87
+#: ./ftw/servicenavigation/form.py:94
 msgid "label_service_links"
 msgstr "Liens de service"
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:178
+#: ./ftw/servicenavigation/form.py:185
 msgid "label_service_navigation"
 msgstr "Navigation de service"
 

--- a/ftw/servicenavigation/locales/ftw.servicenavigation.pot
+++ b/ftw/servicenavigation/locales/ftw.servicenavigation.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-24 09:25+0000\n"
+"POT-Creation-Date: 2019-08-19 12:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,8 +38,13 @@ msgstr ""
 msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
+#. Default: "Open in new window"
+#: ./ftw/servicenavigation/form.py:84
+msgid "label_blank"
+msgstr ""
+
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:97
+#: ./ftw/servicenavigation/form.py:104
 msgid "label_disable_service_links"
 msgstr ""
 
@@ -59,17 +64,17 @@ msgid "label_internal_link"
 msgstr ""
 
 #. Default: "Modify service navigation"
-#: ./ftw/servicenavigation/templates/viewlet.pt:22
+#: ./ftw/servicenavigation/templates/viewlet.pt:23
 msgid "label_modify_service_navigation"
 msgstr ""
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:87
+#: ./ftw/servicenavigation/form.py:94
 msgid "label_service_links"
 msgstr ""
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:178
+#: ./ftw/servicenavigation/form.py:185
 msgid "label_service_navigation"
 msgstr ""
 

--- a/ftw/servicenavigation/locales/ftw.servicenavigation.pot
+++ b/ftw/servicenavigation/locales/ftw.servicenavigation.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-19 12:31+0000\n"
+"POT-Creation-Date: 2019-08-19 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Install ftw.servicenavigation"
 msgstr ""
 
-#: ./ftw/servicenavigation/form.py:61
+#: ./ftw/servicenavigation/form.py:63
 msgid "Label"
 msgstr ""
 
@@ -30,6 +30,11 @@ msgstr ""
 msgid "Service navigation"
 msgstr ""
 
+#. Default: "Choose between an external or an internal link."
+#: ./ftw/servicenavigation/form.py:95
+msgid "error_link_validator"
+msgstr ""
+
 #: ./ftw/servicenavigation/profiles.zcml:13
 msgid "ftw.servicenavigation (default)"
 msgstr ""
@@ -39,27 +44,27 @@ msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
 #. Default: "Open in new window"
-#: ./ftw/servicenavigation/form.py:84
+#: ./ftw/servicenavigation/form.py:86
 msgid "label_blank"
 msgstr ""
 
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:104
+#: ./ftw/servicenavigation/form.py:112
 msgid "label_disable_service_links"
 msgstr ""
 
 #. Default: "External URL"
-#: ./ftw/servicenavigation/form.py:72
+#: ./ftw/servicenavigation/form.py:74
 msgid "label_external_url"
 msgstr ""
 
 #. Default: "Icon"
-#: ./ftw/servicenavigation/form.py:66
+#: ./ftw/servicenavigation/form.py:68
 msgid "label_icon"
 msgstr ""
 
 #. Default: "Internal link"
-#: ./ftw/servicenavigation/form.py:78
+#: ./ftw/servicenavigation/form.py:80
 msgid "label_internal_link"
 msgstr ""
 
@@ -69,12 +74,12 @@ msgid "label_modify_service_navigation"
 msgstr ""
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:94
+#: ./ftw/servicenavigation/form.py:102
 msgid "label_service_links"
 msgstr ""
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:185
+#: ./ftw/servicenavigation/form.py:193
 msgid "label_service_navigation"
 msgstr ""
 

--- a/ftw/servicenavigation/locales/it/LC_MESSAGES/ftw.servicenavigation.po
+++ b/ftw/servicenavigation/locales/it/LC_MESSAGES/ftw.servicenavigation.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-24 09:25+0000\n"
+"POT-Creation-Date: 2019-08-19 12:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,8 +38,13 @@ msgstr ""
 msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
+#. Default: "Open in new window"
+#: ./ftw/servicenavigation/form.py:84
+msgid "label_blank"
+msgstr ""
+
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:97
+#: ./ftw/servicenavigation/form.py:104
 msgid "label_disable_service_links"
 msgstr ""
 
@@ -59,17 +64,17 @@ msgid "label_internal_link"
 msgstr "Link interno"
 
 #. Default: "Modify service navigation"
-#: ./ftw/servicenavigation/templates/viewlet.pt:22
+#: ./ftw/servicenavigation/templates/viewlet.pt:23
 msgid "label_modify_service_navigation"
 msgstr "Modifica navigazione servizi"
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:87
+#: ./ftw/servicenavigation/form.py:94
 msgid "label_service_links"
 msgstr "Link di servizio"
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:178
+#: ./ftw/servicenavigation/form.py:185
 msgid "label_service_navigation"
 msgstr "Navigazione servizi"
 

--- a/ftw/servicenavigation/locales/it/LC_MESSAGES/ftw.servicenavigation.po
+++ b/ftw/servicenavigation/locales/it/LC_MESSAGES/ftw.servicenavigation.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-19 12:31+0000\n"
+"POT-Creation-Date: 2019-08-19 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Install ftw.servicenavigation"
 msgstr ""
 
-#: ./ftw/servicenavigation/form.py:61
+#: ./ftw/servicenavigation/form.py:63
 msgid "Label"
 msgstr ""
 
@@ -30,6 +30,11 @@ msgstr ""
 msgid "Service navigation"
 msgstr "Navigazione servizi"
 
+#. Default: "Choose between an external or an internal link."
+#: ./ftw/servicenavigation/form.py:95
+msgid "error_link_validator"
+msgstr ""
+
 #: ./ftw/servicenavigation/profiles.zcml:13
 msgid "ftw.servicenavigation (default)"
 msgstr ""
@@ -39,27 +44,27 @@ msgid "ftw.servicenavigation : uninstall"
 msgstr ""
 
 #. Default: "Open in new window"
-#: ./ftw/servicenavigation/form.py:84
+#: ./ftw/servicenavigation/form.py:86
 msgid "label_blank"
 msgstr ""
 
 #. Default: "Disable service links"
-#: ./ftw/servicenavigation/form.py:104
+#: ./ftw/servicenavigation/form.py:112
 msgid "label_disable_service_links"
 msgstr ""
 
 #. Default: "External URL"
-#: ./ftw/servicenavigation/form.py:72
+#: ./ftw/servicenavigation/form.py:74
 msgid "label_external_url"
 msgstr "URL esterni"
 
 #. Default: "Icon"
-#: ./ftw/servicenavigation/form.py:66
+#: ./ftw/servicenavigation/form.py:68
 msgid "label_icon"
 msgstr ""
 
 #. Default: "Internal link"
-#: ./ftw/servicenavigation/form.py:78
+#: ./ftw/servicenavigation/form.py:80
 msgid "label_internal_link"
 msgstr "Link interno"
 
@@ -69,12 +74,12 @@ msgid "label_modify_service_navigation"
 msgstr "Modifica navigazione servizi"
 
 #. Default: "Service links"
-#: ./ftw/servicenavigation/form.py:94
+#: ./ftw/servicenavigation/form.py:102
 msgid "label_service_links"
 msgstr "Link di servizio"
 
 #. Default: "Service navigation"
-#: ./ftw/servicenavigation/form.py:185
+#: ./ftw/servicenavigation/form.py:193
 msgid "label_service_navigation"
 msgstr "Navigazione servizi"
 

--- a/ftw/servicenavigation/templates/viewlet.pt
+++ b/ftw/servicenavigation/templates/viewlet.pt
@@ -13,7 +13,8 @@
             <tal:loop repeat="link links">
                 <li>
                     <a tal:attributes="class string:fa-icon fa-${link/icon};
-                                       href link/url"
+                                       href link/url;
+                                       target link/target"
                        tal:content="link/label" />
                 </li>
             </tal:loop>

--- a/ftw/servicenavigation/viewlet.py
+++ b/ftw/servicenavigation/viewlet.py
@@ -36,7 +36,8 @@ class ServiceNavigation(ViewletBase):
                 links.append(
                     dict(label=link['label'],
                          icon=link['icon'],
-                         url=link_url))
+                         url=link_url,
+                         target='_blank' if link.get('blank', False) else ''))
 
         return links
 


### PR DESCRIPTION
This PR implements:

- [x] the possibility to define if a link should open in a new window or not
- [x] a validator validating if there is not both, an external and an internal link defined

<img width="1041" alt="Bildschirmfoto 2019-08-19 um 15 52 35" src="https://user-images.githubusercontent.com/557005/63270957-69a95280-c299-11e9-91bd-e223f5e2991d.png">


<img width="317" alt="Bildschirmfoto 2019-08-19 um 15 32 31" src="https://user-images.githubusercontent.com/557005/63269504-a0ca3480-c296-11e9-9f25-f50c35a5bbc6.png">

Issuer: https://extranet.4teamwork.ch/extern/0202-projekt-edubs-ict-basler-schulen/tracker-edubs/1126